### PR TITLE
Add a Personal User manual to Portfolio

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -12,6 +12,10 @@
     background-size: cover;
 }
 
+#manual-container {
+    background: url(https://images.unsplash.com/photo-1452421822248-d4c2b47f0c81?q=80&w=3774&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D);
+}
+
 .header {
     width: 100%;
     position: relative;

--- a/user_manual.html
+++ b/user_manual.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" type="text/css" href="CSS/style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Oleo+Script+Swash+Caps:wght@700&family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css" integrity="sha512-KfkfwYDsLkIlwQp6LFnl8zNdLGxu9YAA1QvwINks4PhcElQSvqcyVLLD9aMhXd13uQjoXtEKNosOWaZqXgel0g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Josefin+Sans&display=swap" rel="stylesheet">
+    <title>Debs' User Manual</title>
+</head>
+
+<body>
+    <div class="container-1">
+        <header class="header" id="header">
+            <nav class="nav container">
+                <div class="nav-menu" id="nav-menu">
+                    <ul class="nav-list grid">
+                        <li class="nav-item">
+                            <a href="#home" class="nav-link">
+                                <i class="uil uil-estate nav-icon"></i>Home
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="#about" class="nav-link">
+                                <i class="uil uil-user nav-icon"></i>About
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="#portfolio" class="nav-link">
+                                <i class="uil uil-scenery nav-icon"></i>Portfolio
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="#contact" class="nav-link">
+                                <i class="uil uil-message nav-icon"></i>Contact Me
+                            </a>
+                        </li>
+                    </ul>
+                    <i class="uil uil-times nav-close" id="nav-close"></i>
+                </div>
+    
+                <div class="nav-btns">
+                    <div class="nav-toggle" id="nav-toggle">
+                        <i class="uil uil-apps"></i>
+                    </div>
+                </div>
+            </nav>
+        </header>
+    </div>
+
+
+    <div class="content">
+        <h4>Hello,</h4>
+        <h1>Here's <span>Debs'</span></h1>
+        <h3>Personal User Manual</h3>
+    </div>
+
+    <section class="about" id="about">
+        <div class="main">
+            <div class="about-text img-responsive">
+                <h2>About Debs</h2>
+                <p>She is a registered nurse and web developer based in Nigeria.</p><br>
+                  <p class="skills"  id="skills">
+                    <h5 class="skills">Languages and Tools!</h5>
+                    <ol class="skills">
+                    <li>HTML, CSS & Bootstrap</li>
+                    <li>Jekyll & Liquid</li>
+                    <li>JavaScript, Python and Django</li>
+                    <li>Version control (Git & Github)</li>
+                  </ol></p>    
+            </div>
+        </div>
+    </section>
+
+    
+    <div class="details" id="about">
+        <div class="title">
+        <h2>Get To Know Me</h2>
+        </div>
+
+        <div class="box">
+            <div class="card">
+                <i class="fa-brands fa-gratipay"></i>
+                <h5>My Best Qualities</h5>
+                <div class="paragraph">
+                    <p>
+                        <ul style="list-style: none;">
+                            <li>Loyalty</li>
+                            <li>Compassion</li>
+                            <li>Sense of humor</li>
+                            <li>Never-give-up attitude</li>
+                        </ul>
+                    </p>
+                </div>
+            </div>
+
+            <div class="card">
+                <i class="fa-solid fa-masks-theater"></i>
+                <h5>My Hobbies</h5>
+                <div class="paragraph">
+                    <p><ul style="list-style: none;">
+                            <li>Blogging.</li>
+                            <li>Volunteering.</li>
+                            <li>Watching movies.</li>
+                            <li>Learning languages.</li>
+                            <li>Listening to music</li>
+                            <li>Collecting currencies.</li>
+                            <li>Travelling & photography.</li></ul>
+                    </p>
+                </div>
+            </div>
+
+            <div class="card">
+                <i class="fa-solid fa-arrow-up-right-dots"></i>
+                <h5>My Priorities</h5>
+                <div class="paragraph">
+                    <p>
+                        <ol style="list-style: none;">
+                            <li>God</li>
+                            <li>Family</li>
+                            <li>Growth</li>
+                            <li>Service</li>
+                        </ol>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div> 
+
+<script src="js/index.js"></script>
+</body>
+</html>

--- a/user_manual.html
+++ b/user_manual.html
@@ -16,7 +16,7 @@
 </head>
 
 <body>
-    <div class="container-1">
+    <div class="container-1" id="manual-container">
         <header class="header" id="header">
             <nav class="nav container">
                 <div class="nav-menu" id="nav-menu">
@@ -57,19 +57,19 @@
 
     <div class="content">
         <h4>This is</h4>
-        <h1><span>Deborah Udoh</span></h1>
+        <h1><span>Deborah Udoh's</span></h1>
         <h3>Personal User Manual</h3>
     </div>
- 
+
     <div class="details" id="about">
         <div class="title">
-        <h2>Things I Do Well</h2>
+        <h2>My Work Schedule</h2>
         </div>
 
         <div class="box">
             <div class="card">
                 <i class="fa-brands fa-gratipay"></i>
-                <h5>Collaborate</h5>
+                <h5>Weekdays</h5>
                 <div class="paragraph">
                     <p>
                         <ul style="list-style: none;">
@@ -81,7 +81,37 @@
 
             <div class="card">
                 <i class="fa-solid fa-masks-theater"></i>
-                <h5>Communicate</h5>
+                <h5>Weekends</h5>
+                <div class="paragraph">
+                    <p><ul style="list-style: none;">
+                            <li></li>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="details" id="about">
+        <div class="title">
+        <h2>Things I Do Well</h2>
+        </div>
+
+        <div class="box">
+            <div class="card">
+                <i class="fa-brands fa-gratipay"></i>
+                <h5>Love & Collaborate</h5>
+                <div class="paragraph">
+                    <p>
+                        <ul style="list-style: none;">
+                            <li></li>
+                        </ul>
+                    </p>
+                </div>
+            </div>
+
+            <div class="card">
+                <i class="fa-solid fa-masks-theater"></i>
+                <h5>Listen & Communicate</h5>
                 <div class="paragraph">
                     <p><ul style="list-style: none;">
                             <li></li>
@@ -91,7 +121,7 @@
 
             <div class="card">
                 <i class="fa-solid fa-arrow-up-right-dots"></i>
-                <h5>Create</h5>
+                <h5>Learn & Create</h5>
                 <div class="paragraph">
                     <p>
                         <ol style="list-style: none;">
@@ -139,6 +169,87 @@
                             <ol style="list-style: none;">
                                 <li></li>
                             </ol>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="details" id="about">
+            <div class="title">
+            <h2>I work best when...</h2>
+            </div>
+    
+            <div class="box">
+                <div class="card">
+                    <i class="fa-brands fa-gratipay"></i>
+                    <h5>Autonomy</h5>
+                    <div class="paragraph">
+                        <p>
+                            <ul style="list-style: none;">
+                                <li></li>
+                            </ul>
+                        </p>
+                    </div>
+                </div>
+    
+                <div class="card">
+                    <i class="fa-solid fa-masks-theater"></i>
+                    <h5>...</h5>
+                    <div class="paragraph">
+                        <p><ul style="list-style: none;">
+                                <li></li>
+                        </p>
+                    </div>
+                </div>
+    
+                <div class="card">
+                    <i class="fa-solid fa-arrow-up-right-dots"></i>
+                    <h5>...</h5>
+                    <div class="paragraph">
+                        <p>
+                            <ol style="list-style: none;">
+                                <li></li>
+                            </ol>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+        <div class="details" id="about">
+            <div class="title">
+            <h2>Random Facts</h2>
+            </div>
+    
+            <div class="box">
+                <div class="card">
+                    <i class="fa-brands fa-gratipay"></i>
+                    <h5>...</h5>
+                    <div class="paragraph">
+                        <p>
+                            <ul style="list-style: none;">
+                                <li></li>
+                            </ul>
+                        </p>
+                    </div>
+                </div>
+    
+                <div class="card">
+                    <i class="fa-solid fa-masks-theater"></i>
+                    <h5>...</h5>
+                    <div class="paragraph">
+                        <p><ul style="list-style: none;">
+                            <li></li>
+                        </p>
+                    </div>
+                </div>
+
+                <div class="card">
+                    <i class="fa-solid fa-masks-theater"></i>
+                    <h5>...</h5>
+                    <div class="paragraph">
+                        <p><ul style="list-style: none;">
+                            <li></li>
                         </p>
                     </div>
                 </div>

--- a/user_manual.html
+++ b/user_manual.html
@@ -56,45 +56,24 @@
 
 
     <div class="content">
-        <h4>Hello,</h4>
-        <h1>Here's <span>Debs'</span></h1>
+        <h4>This is</h4>
+        <h1><span>Deborah Udoh</span></h1>
         <h3>Personal User Manual</h3>
     </div>
-
-    <section class="about" id="about">
-        <div class="main">
-            <div class="about-text img-responsive">
-                <h2>About Debs</h2>
-                <p>She is a registered nurse and web developer based in Nigeria.</p><br>
-                  <p class="skills"  id="skills">
-                    <h5 class="skills">Languages and Tools!</h5>
-                    <ol class="skills">
-                    <li>HTML, CSS & Bootstrap</li>
-                    <li>Jekyll & Liquid</li>
-                    <li>JavaScript, Python and Django</li>
-                    <li>Version control (Git & Github)</li>
-                  </ol></p>    
-            </div>
-        </div>
-    </section>
-
-    
+ 
     <div class="details" id="about">
         <div class="title">
-        <h2>Get To Know Me</h2>
+        <h2>Things I Do Well</h2>
         </div>
 
         <div class="box">
             <div class="card">
                 <i class="fa-brands fa-gratipay"></i>
-                <h5>My Best Qualities</h5>
+                <h5>Collaborate</h5>
                 <div class="paragraph">
                     <p>
                         <ul style="list-style: none;">
-                            <li>Loyalty</li>
-                            <li>Compassion</li>
-                            <li>Sense of humor</li>
-                            <li>Never-give-up attitude</li>
+                            <li></li>
                         </ul>
                     </p>
                 </div>
@@ -102,32 +81,66 @@
 
             <div class="card">
                 <i class="fa-solid fa-masks-theater"></i>
-                <h5>My Hobbies</h5>
+                <h5>Communicate</h5>
                 <div class="paragraph">
                     <p><ul style="list-style: none;">
-                            <li>Blogging.</li>
-                            <li>Volunteering.</li>
-                            <li>Watching movies.</li>
-                            <li>Learning languages.</li>
-                            <li>Listening to music</li>
-                            <li>Collecting currencies.</li>
-                            <li>Travelling & photography.</li></ul>
+                            <li></li>
                     </p>
                 </div>
             </div>
 
             <div class="card">
                 <i class="fa-solid fa-arrow-up-right-dots"></i>
-                <h5>My Priorities</h5>
+                <h5>Create</h5>
                 <div class="paragraph">
                     <p>
                         <ol style="list-style: none;">
-                            <li>God</li>
-                            <li>Family</li>
-                            <li>Growth</li>
-                            <li>Service</li>
+                            <li></li>
                         </ol>
                     </p>
+                </div>
+            </div>
+        </div>
+
+
+        <div class="details" id="about">
+            <div class="title">
+            <h2>Things I Struggle With</h2>
+            </div>
+    
+            <div class="box">
+                <div class="card">
+                    <i class="fa-brands fa-gratipay"></i>
+                    <h5>Power</h5>
+                    <div class="paragraph">
+                        <p>
+                            <ul style="list-style: none;">
+                                <li></li>
+                            </ul>
+                        </p>
+                    </div>
+                </div>
+    
+                <div class="card">
+                    <i class="fa-solid fa-masks-theater"></i>
+                    <h5>Internet Access</h5>
+                    <div class="paragraph">
+                        <p><ul style="list-style: none;">
+                                <li></li>
+                        </p>
+                    </div>
+                </div>
+    
+                <div class="card">
+                    <i class="fa-solid fa-arrow-up-right-dots"></i>
+                    <h5>Bicycle Face</h5>
+                    <div class="paragraph">
+                        <p>
+                            <ol style="list-style: none;">
+                                <li></li>
+                            </ol>
+                        </p>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Debs is curating a personal user manual as inspired by the conversations in [this issue](https://github.com/open-life-science/internal-policies-and-procedures/issues/98). What better place to add that than in her portfolio?

<img width="1920" alt="Screenshot 2024-10-02 at 19 12 25" src="https://github.com/user-attachments/assets/cebfc1ad-65a8-49ca-a2b7-9f144493b937">
